### PR TITLE
Trying sequential compute - Threadscope experiments

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@ import Grad
 import System.Environment(getArgs)
 import System.Exit(die)
 import Data.List(isInfixOf)
-import Data.Array.Repa( Array, fromListUnboxed, backpermute, foldP, computeP, toList, D, U, Source, extent )
+import Data.Array.Repa( Array, fromListUnboxed, backpermute, foldP, computeS, computeP, toList, D, U, Source, extent )
 import Data.Array.Repa.Index
 
 {- |
@@ -38,7 +38,7 @@ main = do
             let guess = read (head $ tail $ tail input) :: [Double]
 
 --            print $ descendTolerance csvData computeGradRowLogistic [5.1,0.1,1.1] (0.00001) (0.001::Double)
-            print $ descendSteps csvData appLoss guess (10000::Int) (0.0000000001::Double)
+            print $ descendSteps csvData appLoss guess (1000::Int) (0.0000000000001::Double)
 --            print $ descendTolerance csvData computeGradRowLogistic [0.0,0.0] (0.001) (0.0001)
 --            print $ descendSteps csvData computeGradRowLogistic [0.0,0.0] (10000::Int) (0.001::Double)
 
@@ -88,7 +88,8 @@ parallelComputeSum :: [[Double]] -> [Double]
 parallelComputeSum nested@(_:_:_) = do
                     let x = fromListUnboxed (Z :. ((length nested)::Int) :. ((length $ (head nested))::Int) ) (concat nested)
                     let xTranspose = transpose2D x
-                    let [xNDTranspose] = computeP xTranspose :: [Array U DIM2 Double]
+--                    let [xNDTranspose] = computeP xTranspose :: [Array U DIM2 Double]
+                    let xNDTranspose = computeS xTranspose :: Array U DIM2 Double
                     let mResult = foldP (+) 0 xNDTranspose
                     result <- mResult
                     toList result

--- a/parallel-gradient-descent.cabal
+++ b/parallel-gradient-descent.cabal
@@ -42,7 +42,7 @@ executable parallel-gradient-descent-exe
       Paths_parallel_gradient_descent
   hs-source-dirs:
       app
-  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -threaded -rtsopts -O2 -fllvm -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , parallel-gradient-descent


### PR DESCRIPTION
Try this with 10,000 rows (no more or less) and some really low noisemag, like 0.01 or something
I have another version of code that we could try to see if the Threadscope issue resolves (but I will put that in a separate PR)
There's a chance that the build fails - if so, remove "-fllvm" from the .cabal file's ghc-options
Otherwise, keep it as it directly helps Threadscope performance